### PR TITLE
Fix compilation for Linux

### DIFF
--- a/src/host/dullahan_host.cpp
+++ b/src/host/dullahan_host.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char* argv[])
 {
     CefMainArgs main_args(argc, argv);
-    return CefExecuteProcess(main_args, NULL, NULL);
+    return CefExecuteProcess(main_args, nullptr, nullptr);
 }
 #endif
 #ifdef WIN32


### PR DESCRIPTION
Compilation on linux fails with:

> dullahan_host.cpp:33:51: error: conversion from ‘long int’ to ‘CefRefPtr<CefApp>’ {aka ‘scoped_refptr<CefApp>’} is ambiguous
>    33 |     return CefExecuteProcess(main_args, NULL, NULL);
>       |                                                   ^

Changing NULL to nullptr allows compilation to proceed.
