### PR TITLE
Enable dullahan  Linux builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,10 +4,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, macos-13]
+        os: [windows-2022, macos-13, ubuntu-22.04]
         addrsize: ["64"]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Linux dependencies
+        if: runner.os == 'linux'
+        run: sudo apt update && sudo apt install -y  ninja-build
+
       - uses: secondlife/action-autobuild@v3
         with:
           addrsize: ${{ matrix.addrsize }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Dullahan CMake file - Callum Prentice - 2020-05-03
 
 ###############################################################################
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.11)
 
 ###############################################################################
 # Dullahan main project/solution
@@ -121,7 +121,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11 -xobjective-c++")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-    if( NOT ENABLE_CXX11_ABI ) 
+    if( NOT ENABLE_CXX11_ABI )
       add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
     endif()
 endif()
@@ -274,7 +274,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         COMMENT "Adding custom manifest...")
 endif()
 
-# Windows commands to copy CEF binaries and 'resources' folders to 
+# Windows commands to copy CEF binaries and 'resources' folders to
 # executable dir since they're needed at runtime
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 ###############################################################################
 cmake_minimum_required(VERSION 3.11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ###############################################################################
 # Dullahan main project/solution

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@
 ###############################################################################
 cmake_minimum_required(VERSION 3.11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_options("-Wno-array-bounds")
+endif()
 
 ###############################################################################
 # Dullahan main project/solution
@@ -19,24 +25,50 @@ function(check_exists variable)
     endif()
 endfunction()
 
-###############################################################################
-# The user must pass in CEF_WRAPPER_DIR and CEF_WRAPPER_BUILD_DIR then we
-# derrive all the other ones we need based on those
-set(CEF_INCLUDE_DIR ${CEF_WRAPPER_DIR}/include)
-set(CEF_RELEASE_LIB_DIR ${CEF_WRAPPER_DIR}/Release)
-set(CEF_RELEASE_DLL_LIB_DIR ${CEF_WRAPPER_BUILD_DIR}/libcef_dll_wrapper/Release)
-set(CEF_RELEASE_BIN_DIR ${CEF_WRAPPER_DIR}/Release)
-set(CEF_RESOURCES_DIR ${CEF_WRAPPER_DIR}/Resources)
+option( USE_SPOTIFY_CEF "Use a prebuild CEF from spotify" Off )
+option( SPOTIFY_CEF_URL "URL to the prebuild CEF from spotify" "" )
 
-# Check if all our variables exist and bail with
-# a fatal error if any of them are missing
-check_exists(CEF_WRAPPER_DIR)
-check_exists(CEF_WRAPPER_BUILD_DIR)
-check_exists(CEF_INCLUDE_DIR)
-check_exists(CEF_RELEASE_LIB_DIR)
-check_exists(CEF_RELEASE_DLL_LIB_DIR)
-check_exists(CEF_RELEASE_BIN_DIR)
-check_exists(CEF_RESOURCES_DIR)
+if( USE_SPOTIFY_CEF )
+    include(FetchContent)
+
+    FetchContent_Declare( cef_prebuild URL  ${SPOTIFY_CEF_URL} )
+    FetchContent_MakeAvailable(cef_prebuild)
+
+    set(CEF_ROOT "${cef_prebuild_SOURCE_DIR}")
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${cef_prebuild_SOURCE_DIR}/cmake")
+    find_package(CEF REQUIRED)
+endif()
+
+
+if( NOT USE_SPOTIFY_CEF )
+    ###############################################################################
+    # The user must pass in CEF_WRAPPER_DIR and CEF_WRAPPER_BUILD_DIR then we
+    # derrive all the other ones we need based on those
+    set(CEF_INCLUDE_DIR ${CEF_WRAPPER_DIR}/include)
+    set(CEF_RELEASE_LIB_DIR ${CEF_WRAPPER_DIR}/Release)
+    set(CEF_RELEASE_DLL_LIB_DIR ${CEF_WRAPPER_BUILD_DIR}/libcef_dll_wrapper/Release)
+    set(CEF_RELEASE_BIN_DIR ${CEF_WRAPPER_DIR}/Release)
+    set(CEF_RESOURCES_DIR ${CEF_WRAPPER_DIR}/Resources)
+
+    # Check if all our variables exist and bail with
+    # a fatal error if any of them are missing
+    check_exists(CEF_WRAPPER_DIR)
+    check_exists(CEF_WRAPPER_BUILD_DIR)
+    check_exists(CEF_INCLUDE_DIR)
+    check_exists(CEF_RELEASE_LIB_DIR)
+    check_exists(CEF_RELEASE_DLL_LIB_DIR)
+    check_exists(CEF_RELEASE_BIN_DIR)
+    check_exists(CEF_RESOURCES_DIR)
+else()
+    set(CEF_INCLUDE_DIR ${cef_prebuild_SOURCE_DIR}/include)
+    set(CEF_RELEASE_LIB_DIR ${cef_prebuild_SOURCE_DIR}/Release)
+    set(CEF_RELEASE_DLL_LIB_DIR ${CEF_WRAPPER_BUILD_DIR}/libcef_dll_wrapper/Release)
+    set(CEF_RELEASE_BIN_DIR ${cef_prebuild_SOURCE_DIR}/Release)
+    set(CEF_RESOURCES_DIR ${cef_prebuild_SOURCE_DIR}/Resources)
+
+    set( CEF_DLL_LIBRARY libcef_dll_wrapper )
+    set( CEF_LIBRARY ${CEF_LIB_RELEASE} )
+endif()
 
 ###############################################################################
 # location of CEF libraries we link against
@@ -78,27 +110,32 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     check_exists(COCOA_FRAMEWORK)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_CXX_LINK_FLAGS "-Wl,--no-keep-memory -Wl,--build-id -Wl,-rpath,'$ORIGIN:$ORIGIN/../lib' -Wl,--exclude-libs,ALL")
-    find_library(
-        CEF_LIBRARY_RELEASE
-        NAMES libcef.so
-        PATHS ${CEF_RELEASE_LIB_DIR}
-        PATH_SUFFIXES release
-    )
-    find_library(
-        CEF_DLL_LIBRARY_RELEASE
-        NAMES libcef_dll_wrapper.a
-        PATHS ${CEF_WRAPPER_BUILD_DIR}/libcef_dll_wrapper/
-        PATH_SUFFIXES release
-    )
+
+    if( NOT USE_SPOTIFY_CEF )
+        find_library(
+            CEF_LIBRARY_RELEASE
+            NAMES libcef.so
+            PATHS ${CEF_RELEASE_LIB_DIR}
+            PATH_SUFFIXES release
+        )
+        find_library(
+            CEF_DLL_LIBRARY_RELEASE
+            NAMES libcef_dll_wrapper.a
+            PATHS ${CEF_WRAPPER_BUILD_DIR}/libcef_dll_wrapper/
+            PATH_SUFFIXES release
+        )
+        set(CEF_LIBRARY ${CEF_LIBRARY_RELEASE} )
+        set(CEF_DLL_LIBRARY ${CEF_DLL_LIBRARY_RELEASE} )
+    else()
+        set( CEF_DLL_LIBRARY libcef_dll_wrapper )
+        set( CEF_LIBRARY ${CEF_LIB_RELEASE} )
+    endif()
 endif()
 
 ###############################################################################
 # Final layer of finding the right libs for each combination
 # of name, platform, configuration, type etc.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(CEF_LIBRARY ${CEF_LIBRARY_RELEASE} )
-  set(CEF_DLL_LIBRARY ${CEF_DLL_LIBRARY_RELEASE} )
-else()
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CEF_LIBRARY
       optimized ${CEF_LIBRARY_RELEASE}
   )
@@ -524,4 +561,28 @@ endif()
 
 if(CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_CONFIGURATION_TYPES "Release")
+endif()
+
+# Install the Dullahan library and host executable
+
+if( USE_SPOTIFY_CEF )
+  install( TARGETS dullahan_host DESTINATION bin/release )
+  install( TARGETS dullahan ${CEF_DLL_LIBRARY} DESTINATION lib/release )
+
+  foreach(binFile IN LISTS CEF_BINARY_FILES)
+	if(IS_DIRECTORY ${CEF_BINARY_DIR_RELEASE}/${binFile} )
+	  install( DIRECTORY ${CEF_BINARY_DIR_RELEASE}/${binFile} DESTINATION lib/release )
+	  install( DIRECTORY ${CEF_BINARY_DIR_RELEASE}/${binFile} DESTINATION bin/release )
+	else()
+	  install( PROGRAMS ${CEF_BINARY_DIR_RELEASE}/${binFile} DESTINATION lib/release )
+	  install( PROGRAMS ${CEF_BINARY_DIR_RELEASE}/${binFile} DESTINATION bin/release )
+	endif()
+  endforeach()
+  foreach(resFile IN LISTS CEF_RESOURCE_FILES)
+	if(IS_DIRECTORY ${CEF_RESOURCE_DIR}/${resFile} )
+	  install( DIRECTORY  ${CEF_RESOURCE_DIR}/${resFile}  DESTINATION resources)
+	else()
+	  install( FILES ${CEF_RESOURCE_DIR}/${resFile}  DESTINATION resources)
+	endif()
+  endforeach()
 endif()

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -28,18 +28,6 @@
             <key>name</key>
             <string>darwin64</string>
           </map>
-          <key>linux64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>fe4c980f5e42196e4ba554e2093dfb3a</string>
-              <key>url</key>
-              <string>http://192.168.1.115/dev/pkg/cef_bin-81.3.10_gb223419_chromium-81.0.4044.138.201451352-linux64-201451352.tar.bz2</string>
-            </map>
-            <key>name</key>
-            <string>darwin64</string>
-          </map>
           <key>windows</key>
           <map>
             <key>archive</key>

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -232,7 +232,7 @@ case "$AUTOBUILD_PLATFORM" in
         #Force version regeneration.
         rm -f src/dullahan_version.h
 
-        cmake -S . -B stage/build  -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_INSTALL_PREFIX=stage \
+        cmake -S . -B stage/build  -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_INSTALL_PREFIX=stage -DENABLE_CXX11_ABI=ON \
         -DUSE_SPOTIFY_CEF=TRUE -DSPOTIFY_CEF_URL=https://cef-builds.spotifycdn.com/cef_binary_118.4.1%2Bg3dd6078%2Bchromium-118.0.5993.54_linux64_beta_minimal.tar.bz2
 		cmake --build stage/build
 		cmake --install stage/build

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -238,6 +238,8 @@ case "$AUTOBUILD_PLATFORM" in
 		cmake --install stage/build
 
         strip stage/lib/release/libcef.so
+	rm stage/bin/release/*.so*
+	rm stage/bin/release/*.json
 
         g++ -std=c++17  -I "${cef_no_wrapper_dir}/include"  -I "${dullahan_source_dir}" -o "$stage/version"  "$top/tools/autobuild_version.cpp"
 


### PR DESCRIPTION
Rght now there is no LL-CEF build ( see [Issue 3 in CEF](https://github.com/secondlife/cef/issues/3) ) to consume.
To get around this, the build with be a bit sneaky and just use a binary from Spotify (the official CEF nightly builds)

Why  no custom built CEF first? I believe this will be a futile exercise trying to attempt this using the free github runners:
- a CEF build needs at least 200GB storage (likely more)
- It runs for like 10+ hours

As a consequence there will be no proprietary codecs; But at least there will be a Linux dullahan, which beats having no browser at all.

@callumlinden or @bennettgoble can one of you review this, merge if golden and please create a release?
