### PR TITLE
Option to disable cookie database locking

### DIFF
--- a/src/dullahan.h
+++ b/src/dullahan.h
@@ -161,6 +161,7 @@ class dullahan
             bool use_mock_keychain = false;             // like adding --use-mock-keychain to Chrome command line
             bool autoplay_without_gesture = false;      // like adding --autoplay-policy=???? to Chrome command line
             bool fake_ui_for_media_stream = false;      // like adding --fake-ui-for-media-stream to Chrome command line
+            bool disable_cookie_database_locking = true;// like adding --disable-features=LockProfileCookieDatabase to the Chrome command line
             bool flash_enabled = true;                  // system flash plugin
             bool force_wave_audio = false;              // forces Windows WaveOut/In audio
             bool image_shrink_standalone_to_fit = true; // scale standalone images larger than browser size to fit

--- a/src/dullahan_impl.cpp
+++ b/src/dullahan_impl.cpp
@@ -180,8 +180,14 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
 
         if (!disable_features.empty())
         {
-            std::string disabled_features = CefString(CefJoinString(disable_features, ',', true));
-            command_line->AppendSwitchWithValue("disable-features", disabled_features);
+            std::ostringstream disabled_features;
+
+			for (size_t i = 0, n = disable_features.size(); i < n; ++i) {
+                if (i > 0) disabled_features << ',';
+                disabled_features << disable_features[i];
+            }
+            
+            command_line->AppendSwitchWithValue("disable-features", disabled_features.str());
         }
 
         platformAddCommandLines(command_line);

--- a/src/dullahan_impl.cpp
+++ b/src/dullahan_impl.cpp
@@ -75,6 +75,7 @@ dullahan_impl::dullahan_impl() :
     mUseMockKeyChain(false),
     mAutoPlayWithoutGesture(false),
     mFakeUIForMediaStream(false),
+    mDisableCookieDatabaseLocking(true),
     mFlipPixelsY(false),
     mFlipMouseY(false),
     mRequestContext(nullptr),
@@ -95,6 +96,8 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
 {
     if (process_type.empty())
     {
+        std::vector<std::string> disable_features;
+
         // <ND> Enable HTMLImports to get youtube live chat to work
         command_line->AppendSwitchWithValue("enable-blink-features", "HTMLImports");
         if (mMediaStreamEnabled == true)
@@ -135,7 +138,7 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
 
         if (mDisableNetworkService)
         {
-            command_line->AppendSwitchWithValue("disable-features", "NetworkService");
+            disable_features.push_back( "NetworkService" );
         }
 
         if (mUseMockKeyChain)
@@ -167,6 +170,19 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
         // it using native Viewer UI as before.
         // Details captured in this GHI: https://github.com/secondlife/viewer-private/issues/489
         command_line->AppendSwitch("disable-chrome-login-prompt");
+
+#ifdef WIN32
+        if (mDisableCookieDatabaseLocking)
+        {
+            disable_features.push_back( "LockProfileCookieDatabase" );
+        }
+#endif
+
+        if (!disable_features.empty())
+        {
+            std::string disabled_features = CefString(CefJoinString(disable_features, ',', true);
+            command_line->AppendSwitchWithValue("disable-features", disabled_features);
+        }
 
         platformAddCommandLines(command_line);
     }
@@ -392,6 +408,12 @@ bool dullahan_impl::initCEF(dullahan::dullahan_settings& user_settings)
     // eventually, this will be implemented as a callback so the consumer can
     // provide their own ("Allow, "Disallow") UI.
     mFakeUIForMediaStream = user_settings.fake_ui_for_media_stream;
+
+    // this flag if set, disables a security measure introduced in Chrome 114 for W32 that
+    // prevents multiple processes from accessing the cookie database. It is recommended to
+    // enable this if the application spawns more than one Dullahan process, or when multiple
+    // simultaneous instances of the application needs to be supported.
+    mDisableCookieDatabaseLocking = user_settings.disable_cookie_database_locking;
 
     // if true, this setting inverts the pixels in Y direction - useful if your texture
     // coords are upside down compared to default for Dullahan

--- a/src/dullahan_impl.cpp
+++ b/src/dullahan_impl.cpp
@@ -138,7 +138,7 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
 
         if (mDisableNetworkService)
         {
-            disable_features.push_back( "NetworkService" );
+            disable_features.push_back("NetworkService");
         }
 
         if (mUseMockKeyChain)
@@ -174,13 +174,13 @@ void dullahan_impl::OnBeforeCommandLineProcessing(const CefString& process_type,
 #ifdef WIN32
         if (mDisableCookieDatabaseLocking)
         {
-            disable_features.push_back( "LockProfileCookieDatabase" );
+            disable_features.push_back("LockProfileCookieDatabase");
         }
 #endif
 
         if (!disable_features.empty())
         {
-            std::string disabled_features = CefString(CefJoinString(disable_features, ',', true);
+            std::string disabled_features = CefString(CefJoinString(disable_features, ',', true));
             command_line->AppendSwitchWithValue("disable-features", disabled_features);
         }
 

--- a/src/dullahan_impl.h
+++ b/src/dullahan_impl.h
@@ -178,6 +178,7 @@ class dullahan_impl :
         bool mUseMockKeyChain;
         bool mAutoPlayWithoutGesture;
         bool mFakeUIForMediaStream;
+        bool mDisableCookieDatabaseLocking;
         bool mFlipPixelsY;
         bool mFlipMouseY;
         double mRequestedPageZoom;


### PR DESCRIPTION
Solving issue: https://feedback.secondlife.com/web-bugs/p/search-asks-me-to-accept-cookies-each-time-i-launch-client

Chrome 114 [added a security measure](https://chromium-review.googlesource.com/c/chromium/src/+/4477644) for Windows systems that prevents malware from stealing cookie or session information, by maintaining a file lock on the corresponding database files.

This security measure is not good for applications like SecondLife that spawn multiple Dullahan processes per instance per profile. Cookies are not remembered between Dullahan sessions, prompting users with cookie walls and logged out sessions every single time.

This pull request disables that security measure by default, to restore it to pre-Chrome 114 behavior, and adds to option to restore the security measure by setting `disable_cookie_database_locking = false` in the CEF settings.