### PR TITLE
Add support for universal(x86_64,arm64) macos build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, macos-13, ubuntu-22.04]
+        os: [windows-2022, macos-15, ubuntu-22.04]
         addrsize: ["64"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This adds support for building dullahan as a universal macOS binary for macOS

The ARM64 build currently uses a Spotify opensource build that matches the current Linden built version.

Companion PR for a cef arm64 SDK bundle https://github.com/secondlife/cef/pull/6