### PR TITLE
Fix CEF filling up %TEMP% on Windows with temp files and never being cleared

### DIFF
--- a/src/dullahan_impl.cpp
+++ b/src/dullahan_impl.cpp
@@ -210,6 +210,23 @@ std::string convert_wide_to_string(const wchar_t* in, unsigned int code_page)
     }
     return out;
 }
+
+std::wstring convert_string_to_wide(const char* in, size_t len, unsigned int code_page)
+{
+    // reserve an output buffer that will be destroyed on exit, with a place
+    // to put NULL terminator
+    std::vector<wchar_t> w_out(len + 1);
+
+    memset(&w_out[0], 0, w_out.size());
+    int real_output_str_len = MultiByteToWideChar(code_page, 0, in, static_cast<int>(len),
+                                                  &w_out[0], static_cast<int>(w_out.size() - 1));
+
+    //looks like MultiByteToWideChar didn't add null terminator to converted string, see EXT-4858.
+    w_out[real_output_str_len] = 0;
+
+    // construct string<wchar_t> from our temporary output buffer
+    return {&w_out[0]};
+}
 #endif
 
 bool dullahan_impl::initCEF(dullahan::dullahan_settings& user_settings)
@@ -410,6 +427,15 @@ bool dullahan_impl::initCEF(dullahan::dullahan_settings& user_settings)
 		// allow Chrome (or other CEF windoW) to debug at http://localhost::PORT_NUMBER
 		settings.remote_debugging_port = user_settings.remote_debugging_port;
 	}
+
+#ifdef WIN32
+    // On Windows there is a large amount of files being created in %TEMP% and never cleaned up
+    // So lets move them to our cache path so they can be cleaned up during CEF cache purges
+    std::string tempPath = user_settings.root_cache_path + "\\cache";
+    std::wstring tempPathW = convert_string_to_wide(tempPath.c_str(), tempPath.length(), CP_UTF8);
+    SetEnvironmentVariableW(L"TMP", tempPathW.c_str());
+    SetEnvironmentVariableW(L"TEMP", tempPathW.c_str());
+#endif
 
     // initiaize CEF
     bool result = CefInitialize(args, settings, this, nullptr);


### PR DESCRIPTION
On Windows, overtime as dullahan is running in the background, it will accumulate a large number of "chrome_BITS" and some "chrome_url_fetcher" temp files in the OS's %TEMP% folder. These never get cleaned up and end up creating hundreds or even thousands of these over the span of a few days.
They are mostly harmless and generally very small in size or just empty folders, but still not ideal just letting %TEMP% fill up with these and no cleanup mechanic.

This PR simply just sets the entire TEMP (and TMP just in case) path on Windows for the given dullahan instance, to point to the cef_cache/pid/cache folder. That way, when the viewer runs and does LLAppViewer::purgeCefStaleCaches, these temp folders will get cleaned up in the process.

(Other platforms may be effected, but from what Beq observed, and me looking on a VM, Linux does not seem to be effected, unsure about macOS however)

<details>
<Summary>Screenshot showing what was happening to %TEMP% after a short period of time having Second Life viewer running-</summary>

<img width="682" height="683" alt="image" src="https://github.com/user-attachments/assets/046581db-1540-46d3-befb-89872401e59e" />

</details>

<details>
<Summary>Screenshot showing after this PR has been applied-</summary>

<img width="760" height="869" alt="image" src="https://github.com/user-attachments/assets/cd9925e4-595f-4a82-9e8d-a95dae057bbd" />

</details>