### PR TITLE
Expose CEF audio stream callbacks through the Dullahan API

### DIFF
--- a/src/dullahan.cpp
+++ b/src/dullahan.cpp
@@ -396,10 +396,32 @@ void dullahan::setOnOpenPopupCallback(std::function<void(const std::string url,
 }
 
 void dullahan::setOnPageChangedCallback(std::function<void(const unsigned char* pixels,
-                                        int x, int y,
-                                        int width, int height)> callback)
+                                      int x, int y,
+                                      int width, int height)> callback)
 {
     mImpl->getCallbackManager()->setOnPageChangedCallback(callback);
+}
+
+void dullahan::setOnAudioStreamStartedCallback(std::function<void(const dullahan_audio_stream_info& info)> callback)
+{
+    mImpl->getCallbackManager()->setOnAudioStreamStartedCallback(callback);
+}
+
+void dullahan::setOnAudioStreamPacketCallback(std::function<void(const float** data,
+                                            int frames,
+                                            int64_t pts)> callback)
+{
+    mImpl->getCallbackManager()->setOnAudioStreamPacketCallback(callback);
+}
+
+void dullahan::setOnAudioStreamStoppedCallback(std::function<void()> callback)
+{
+    mImpl->getCallbackManager()->setOnAudioStreamStoppedCallback(callback);
+}
+
+void dullahan::setOnAudioStreamErrorCallback(std::function<void(const std::string message)> callback)
+{
+    mImpl->getCallbackManager()->setOnAudioStreamErrorCallback(callback);
 }
 
 void dullahan::setOnRequestExitCallback(std::function<void()> callback)

--- a/src/dullahan.h
+++ b/src/dullahan.h
@@ -130,6 +130,14 @@ class dullahan
             FD_SAVE_FILE,
         } EFileDialogType;
 
+        struct dullahan_audio_stream_info
+        {
+            int sample_rate = 0;
+            int channels = 0;
+            int channel_layout = 0;
+            int frames_per_buffer = 0;
+        };
+
     public:
         //////////// initialization settings ////////////
         struct dullahan_settings
@@ -368,6 +376,20 @@ class dullahan
         void setOnPageChangedCallback(std::function<void(const unsigned char* pixels,
                                       int x, int y,
                                       int width, int height)> callback);
+
+        // browser audio stream starts
+        void setOnAudioStreamStartedCallback(std::function<void(const dullahan_audio_stream_info& info)> callback);
+
+        // browser audio PCM packet. Data is planar float PCM and valid only during the callback.
+        void setOnAudioStreamPacketCallback(std::function<void(const float** data,
+                                            int frames,
+                                            int64_t pts)> callback);
+
+        // browser audio stream stops
+        void setOnAudioStreamStoppedCallback(std::function<void()> callback);
+
+        // browser audio stream error
+        void setOnAudioStreamErrorCallback(std::function<void(const std::string message)> callback);
 
         // exit app requested
         void setOnRequestExitCallback(std::function<void()> callback);

--- a/src/dullahan_browser_client.cpp
+++ b/src/dullahan_browser_client.cpp
@@ -96,6 +96,43 @@ bool dullahan_browser_client::OnBeforePopup(CefRefPtr<CefBrowser> browser,
     return true;
 }
 
+bool dullahan_browser_client::GetAudioParameters(CefRefPtr<CefBrowser> browser,
+                                                 CefAudioParameters& params)
+{
+    return true;
+}
+
+void dullahan_browser_client::OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
+                                                   const CefAudioParameters& params,
+                                                   int channels)
+{
+    dullahan::dullahan_audio_stream_info info;
+    info.sample_rate = params.sample_rate;
+    info.channels = channels;
+    info.channel_layout = static_cast<int>(params.channel_layout);
+    info.frames_per_buffer = params.frames_per_buffer;
+    mParent->getCallbackManager()->onAudioStreamStarted(info);
+}
+
+void dullahan_browser_client::OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
+                                                  const float** data,
+                                                  int frames,
+                                                  int64_t pts)
+{
+    mParent->getCallbackManager()->onAudioStreamPacket(data, frames, pts);
+}
+
+void dullahan_browser_client::OnAudioStreamStopped(CefRefPtr<CefBrowser> browser)
+{
+    mParent->getCallbackManager()->onAudioStreamStopped();
+}
+
+void dullahan_browser_client::OnAudioStreamError(CefRefPtr<CefBrowser> browser,
+                                                 const CefString& message)
+{
+    mParent->getCallbackManager()->onAudioStreamError(std::string(message));
+}
+
 // CefLifeSpanHandler override
 void dullahan_browser_client::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 {

--- a/src/dullahan_browser_client.cpp
+++ b/src/dullahan_browser_client.cpp
@@ -99,6 +99,9 @@ bool dullahan_browser_client::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 bool dullahan_browser_client::GetAudioParameters(CefRefPtr<CefBrowser> browser,
                                                  CefAudioParameters& params)
 {
+    params.channel_layout = CEF_CHANNEL_LAYOUT_7_1;
+    params.sample_rate = 48000;
+    params.frames_per_buffer = 1024;
     return true;
 }
 

--- a/src/dullahan_browser_client.h
+++ b/src/dullahan_browser_client.h
@@ -29,6 +29,7 @@
 
 #include <list>
 
+#include "cef_audio_handler.h"
 #include "cef_client.h"
 
 class dullahan_impl;
@@ -42,7 +43,8 @@ class dullahan_browser_client :
     public CefRequestHandler,
     public CefDownloadHandler,
     public CefDialogHandler,
-    public CefJSDialogHandler
+    public CefJSDialogHandler,
+    public CefAudioHandler
 {
     public:
         dullahan_browser_client(dullahan_impl* parent,
@@ -51,6 +53,10 @@ class dullahan_browser_client :
 
         // CefClient override
         CefRefPtr<CefRenderHandler> GetRenderHandler() override;
+        CefRefPtr<CefAudioHandler> GetAudioHandler() override
+        {
+            return this;
+        }
 
         // CefLifeSpanHandler overrides
         CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override
@@ -166,6 +172,20 @@ class dullahan_browser_client :
                                   const CefString& message_text,
                                   bool is_reload,
                                   CefRefPtr<CefJSDialogCallback> callback) override;
+
+        // CefAudioHandler overrides
+        bool GetAudioParameters(CefRefPtr<CefBrowser> browser,
+                                CefAudioParameters& params) override;
+        void OnAudioStreamStarted(CefRefPtr<CefBrowser> browser,
+                                  const CefAudioParameters& params,
+                                  int channels) override;
+        void OnAudioStreamPacket(CefRefPtr<CefBrowser> browser,
+                                 const float** data,
+                                 int frames,
+                                 int64_t pts) override;
+        void OnAudioStreamStopped(CefRefPtr<CefBrowser> browser) override;
+        void OnAudioStreamError(CefRefPtr<CefBrowser> browser,
+                                const CefString& message) override;
     private:
         dullahan_impl* mParent;
         CefRefPtr<CefRenderHandler> mRenderHandler;

--- a/src/dullahan_callback_manager.cpp
+++ b/src/dullahan_callback_manager.cpp
@@ -165,6 +165,60 @@ void dullahan_callback_manager::onPageChanged(const unsigned char* pixels, int x
     }
 }
 
+void dullahan_callback_manager::setOnAudioStreamStartedCallback(
+    std::function<void(const dullahan::dullahan_audio_stream_info& info)> callback)
+{
+    mOnAudioStreamStartedCallbackFunc = callback;
+}
+
+void dullahan_callback_manager::onAudioStreamStarted(const dullahan::dullahan_audio_stream_info& info)
+{
+    if (mOnAudioStreamStartedCallbackFunc)
+    {
+        mOnAudioStreamStartedCallbackFunc(info);
+    }
+}
+
+void dullahan_callback_manager::setOnAudioStreamPacketCallback(
+    std::function<void(const float** data, int frames, int64_t pts)> callback)
+{
+    mOnAudioStreamPacketCallbackFunc = callback;
+}
+
+void dullahan_callback_manager::onAudioStreamPacket(const float** data, int frames, int64_t pts)
+{
+    if (mOnAudioStreamPacketCallbackFunc)
+    {
+        mOnAudioStreamPacketCallbackFunc(data, frames, pts);
+    }
+}
+
+void dullahan_callback_manager::setOnAudioStreamStoppedCallback(std::function<void()> callback)
+{
+    mOnAudioStreamStoppedCallbackFunc = callback;
+}
+
+void dullahan_callback_manager::onAudioStreamStopped()
+{
+    if (mOnAudioStreamStoppedCallbackFunc)
+    {
+        mOnAudioStreamStoppedCallbackFunc();
+    }
+}
+
+void dullahan_callback_manager::setOnAudioStreamErrorCallback(std::function<void(const std::string message)> callback)
+{
+    mOnAudioStreamErrorCallbackFunc = callback;
+}
+
+void dullahan_callback_manager::onAudioStreamError(const std::string message)
+{
+    if (mOnAudioStreamErrorCallbackFunc)
+    {
+        mOnAudioStreamErrorCallbackFunc(message);
+    }
+}
+
 void dullahan_callback_manager::setOnStatusMessageCallback(std::function<void(const std::string message)> callback)
 {
     mOnStatusMessageCallbackFunc = callback;
@@ -291,4 +345,3 @@ bool dullahan_callback_manager::onJSBeforeUnloadCallback()
     // default to cancel request if no callback set up
     return false;
 }
-

--- a/src/dullahan_callback_manager.h
+++ b/src/dullahan_callback_manager.h
@@ -64,6 +64,18 @@ class dullahan_callback_manager
         void setOnPageChangedCallback(std::function<void(const unsigned char* pixels, int x, int y, int width, int height)> callback);
         void onPageChanged(const unsigned char* pixels, int x, int y, int width, int height);
 
+        void setOnAudioStreamStartedCallback(std::function<void(const dullahan::dullahan_audio_stream_info& info)> callback);
+        void onAudioStreamStarted(const dullahan::dullahan_audio_stream_info& info);
+
+        void setOnAudioStreamPacketCallback(std::function<void(const float** data, int frames, int64_t pts)> callback);
+        void onAudioStreamPacket(const float** data, int frames, int64_t pts);
+
+        void setOnAudioStreamStoppedCallback(std::function<void()> callback);
+        void onAudioStreamStopped();
+
+        void setOnAudioStreamErrorCallback(std::function<void(const std::string message)> callback);
+        void onAudioStreamError(const std::string message);
+
         void setOnStatusMessageCallback(std::function<void(const std::string message)> callback);
         void onStatusMessage(const std::string message);
 
@@ -102,6 +114,10 @@ class dullahan_callback_manager
         std::function<void()> mOnLoadStartCallbackFunc;
         std::function<void(const std::string, const std::string)> mOnOpenPopupCallbackFunc;
         std::function<void(const unsigned char*, int, int, int, int)> mOnPageChangedCallbackFunc;
+        std::function<void(const dullahan::dullahan_audio_stream_info&)> mOnAudioStreamStartedCallbackFunc;
+        std::function<void(const float**, int, int64_t)> mOnAudioStreamPacketCallbackFunc;
+        std::function<void()> mOnAudioStreamStoppedCallbackFunc;
+        std::function<void(const std::string)> mOnAudioStreamErrorCallbackFunc;
         std::function<void(const std::string)> mOnStatusMessageCallbackFunc;
         std::function<void()> mOnRequestExitCallbackFunc;
         std::function<void(const std::string)> mOnTitleChangeCallbackFunc;


### PR DESCRIPTION
# Note

This is my first time opening a pull request to this project, so please let me know if I should adjust the format, scope, or explanation.

Thank you for maintaining Dullahan and the technical foundation that keeps MOAP media playback working in Second Life viewers. Dullahan is also an important part of my own creative work in Second Life, where I perform music as "Tia Rungray", so I appreciate the long-term maintenance of this project and the systems it supports.

# Summary

This PR exposes CEF audio stream callbacks through the Dullahan public API.

Embedding applications can now receive browser audio as planar float PCM instead of relying only on the native OS audio output selected by CEF. Dullahan forwards the CEF audio stream events to the embedder and does not resample, mix, buffer, or play the audio itself.

The new public callbacks are:

- `setOnAudioStreamStartedCallback(...)`
- `setOnAudioStreamPacketCallback(...)`
- `setOnAudioStreamStoppedCallback(...)`
- `setOnAudioStreamErrorCallback(...)`

# Motivation

AYAstorm is a downstream Firestorm / Second Life viewer that embeds Dullahan for web media:

https://github.com/mayatonton/phoenix-firestorm.git

In that viewer, media and MOAP audio need to be routed through the viewer audio system instead of bypassing it through CEF's native audio output. This lets the viewer apply its own media volume, mute, buffering, routing, and spatial-audio policy.

AYAstorm also has a 3D Stream spatial audio system built on FMOD APIs. For that use case, browser media audio has to be available to the viewer as decoded PCM so the downstream application can route it into FMOD channel groups, 3D channels, speaker placement, rolloff, occlusion, binaural / HRTF processing, and related DSP.

Dullahan should not own that playback policy. This PR only adds the API boundary needed for embedders to receive the audio stream and make their own routing decisions.

# Audio Format Rationale

`GetAudioParameters()` currently requests this CEF audio format:

```cpp
params.channel_layout = CEF_CHANNEL_LAYOUT_7_1;
params.sample_rate = 48000;
params.frames_per_buffer = 1024;
```

The values are intended to provide a stable decoded PCM contract for downstream audio routing, not to make Dullahan implement 7.1 playback itself.

- `CEF_CHANNEL_LAYOUT_7_1` is used as a surround-capable callback bus. The main downstream target is Ogg Opus 6-channel / 5.1 streaming, but Ogg Opus mapping family 1 defines conventional surround layouts from 1 to 8 channels, including 5.1 and 7.1. Requesting a 7.1 callback layout preserves channel identity for surround sources before the embedder maps the PCM into its own audio engine.
- `48000` Hz matches Opus fullband audio and the 48 kHz timing model used by Ogg Opus. It also matches the downstream AYAstorm / FMOD 3D Stream processing path.
- `1024` frames is the packet granularity used by the downstream media ring / FMOD callback path, avoiding an extra repacketization step in the embedder.

Chromium supports Opus as a default audio decoder type, so Ogg Opus surround streams that Chromium / CEF can play as web media can be exposed to the embedder as decoded PCM through this callback API.

References:

- Ogg Opus, RFC 7845: https://www.rfc-editor.org/rfc/rfc7845.html
- Opus, RFC 6716: https://www.rfc-editor.org/rfc/rfc6716.html
- Chromium default audio decoder support: https://chromium.googlesource.com/chromium/src/+/main/media/base/supported_types.cc

# Implementation Notes

- `dullahan_browser_client` now implements `CefAudioHandler`.
- `GetAudioHandler()` returns the browser client so CEF can deliver audio stream events.
- `OnAudioStreamStarted()` reports sample rate, channel count, channel layout, and frames per buffer through `dullahan_audio_stream_info`.
- `OnAudioStreamPacket()` forwards CEF's `const float** data`, `frames`, and `pts` to the callback manager.
- The PCM pointer is owned by CEF and is only valid during the packet callback. Embedders must copy it during the callback if they need to keep it.
- If no callback is registered, Dullahan does nothing, matching the existing callback-manager pattern.

# Compatibility

This is intended to be source-compatible for existing Dullahan users:

- Existing callback APIs are unchanged.
- The new audio stream callbacks are opt-in.
- Dullahan does not add playback, buffering, mixing, or resampling behavior.

The main behavior change is that `dullahan_browser_client` now provides a `CefAudioHandler` and requests the audio format shown above.

# Testing

Validated in the AYAstorm downstream viewer:

- Viewer builds completed using this Dullahan package.
- Runtime behavior was checked on macOS, Windows, and Linux.
- Browser media / MOAP audio could be routed through the viewer-side FMOD media path.
- Viewer media volume and mute affected the routed media audio.
- Short playback runs did not show continuously increasing audio ring drops or silence insertion after buffer tuning.

# Review Focus

- Is this the right API shape for exposing CEF audio to Dullahan embedders?
- Is forwarding `const float** data` with callback-lifetime validity acceptable for this API?
- Should `GetAudioHandler()` always return `this`, or only when audio callbacks are registered?
- Is the requested `CEF_CHANNEL_LAYOUT_7_1` / `48000` / `1024` audio format acceptable as the default callback contract?