### PR TITLE
Add embed:// scheme for serving trusted local content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,8 @@ add_library(
     src/dullahan_callback_manager.cpp
     src/dullahan_callback_manager.h
     src/dullahan_debug.h
+    src/dullahan_embed_scheme.cpp
+    src/dullahan_embed_scheme.h
     src/dullahan_impl.cpp
     src/dullahan_impl.h
     src/dullahan_version.h

--- a/examples/opengl-example/src/opengl-example.cpp
+++ b/examples/opengl-example/src/opengl-example.cpp
@@ -329,7 +329,7 @@ bool openglExample::init()
 
         mDullahan->setOnPageChangedCallback(std::bind(&openglExample::onPageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
         mDullahan->setOnRequestExitCallback(std::bind(&openglExample::onRequestExitCallback, this));
-        mDullahan->setOnJStoCPPMsgCallback(std::bind(&openglExample::onJStoCPPMsgCallback, this, std::placeholders::_1, std::placeholders::_2));
+        mDullahan->setOnJStoCPPMsgCallback(std::bind(&openglExample::onJStoCPPMsgCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         
         mDullahan->navigate(mHomeUrl);
     }
@@ -482,9 +482,9 @@ void openglExample::onRequestExitCallback()
     glfwSetWindowShouldClose(mWindow, GLFW_TRUE);
 }
 
-std::string openglExample::onJStoCPPMsgCallback(const std::string id, const std::string msg)
+std::string openglExample::onJStoCPPMsgCallback(const std::string id, const std::string msg, const std::string frame_url)
 {
-    std::cout << "Received message with ID: " << id << " from JavaScript: " << msg << std::endl;
+    std::cout << "Received message with ID: " << id << " from JavaScript: " << msg << " (origin: " << frame_url << ")" << std::endl;
     return "Message received loud and clear by C++!";
 }
 

--- a/examples/opengl-example/src/opengl-example.h
+++ b/examples/opengl-example/src/opengl-example.h
@@ -69,7 +69,7 @@ class openglExample
         // callbacks
         void onPageChanged(const unsigned char* pixels, int x, int y, const int width, const int height);
         void onRequestExitCallback();
-        std::string onJStoCPPMsgCallback(const std::string id, const std::string msg);
+        std::string onJStoCPPMsgCallback(const std::string id, const std::string msg, const std::string frame_url);
 
     private:
         GLFWwindow* mWindow;

--- a/src/dullahan.cpp
+++ b/src/dullahan.cpp
@@ -344,6 +344,26 @@ std::vector<std::string>& dullahan::getCustomSchemes()
     return mImpl->getCustomSchemes();
 }
 
+void dullahan::setEmbedSchemeRoot(const std::string& root_dir)
+{
+    mImpl->setEmbedSchemeRoot(root_dir);
+}
+
+const std::string& dullahan::getEmbedSchemeRoot()
+{
+    return mImpl->getEmbedSchemeRoot();
+}
+
+void dullahan::setEmbedRegistry(const std::vector<std::string>& allowed_paths)
+{
+    mImpl->setEmbedRegistry(allowed_paths);
+}
+
+const std::vector<std::string>& dullahan::getEmbedRegistry()
+{
+    return mImpl->getEmbedRegistry();
+}
+
 void dullahan::setOnAddressChangeCallback(std::function<void(const std::string url)> callback)
 {
     mImpl->getCallbackManager()->setOnAddressChangeCallback(callback);
@@ -447,7 +467,7 @@ void dullahan::setOnJSBeforeUnloadCallback(std::function<bool()> callback)
     mImpl->getCallbackManager()->setOnJSBeforeUnloadCallback(callback);
 }
 
-void dullahan::setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg)> callback)
+void dullahan::setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg, const std::string frame_url)> callback)
 {
     mImpl->getCallbackManager()->setOnJStoCPPMsgCallback(callback);
 }

--- a/src/dullahan.h
+++ b/src/dullahan.h
@@ -330,6 +330,14 @@ class dullahan
         void setCustomSchemes(std::vector<std::string> custom_schemes);
         std::vector<std::string>& getCustomSchemes();
 
+        // The embed:// scheme is intended to host trusted local resources bundled by the host application.
+        // Resources are mapped as: embed://<host>/<path> => <root>/<host>/<path>
+        // Only paths that appear in the registry (relative to <root>, using forward slashes) are served.
+        void setEmbedSchemeRoot(const std::string& root_dir);
+        const std::string& getEmbedSchemeRoot();
+        void setEmbedRegistry(const std::vector<std::string>& allowed_paths);
+        const std::vector<std::string>& getEmbedRegistry();
+
         //////////// callback setters ////////////
         // URL changes - e.g. redirect
         void setOnAddressChangeCallback(std::function<void(const std::string url)> callback);
@@ -397,8 +405,10 @@ class dullahan
         // JS before unload callback (alert)
         void setOnJSBeforeUnloadCallback(std::function<bool()> callback);
 
-        // Message from JS to CPP
-        void setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg)> callback);
+        // Message from JS to CPP.
+        // The frame_url argument identifies the origin of the calling frame,
+        // allowing consumers to filter messages by origin if needed.
+        void setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg, const std::string frame_url)> callback);
 
     private:
         std::unique_ptr <dullahan_impl> mImpl;

--- a/src/dullahan_browser_client.cpp
+++ b/src/dullahan_browser_client.cpp
@@ -324,6 +324,14 @@ bool dullahan_browser_client::OnBeforeBrowse(CefRefPtr<CefBrowser> browser,
         }
     }
 
+    // Track whether the main frame is currently loading embed:// content so
+    // OnBeforeResourceLoad has a reliable trust-context signal that doesn't
+    // depend on the racy frame URL update visible on the IO thread.
+    if (frame && frame->IsMain())
+    {
+        mEmbedScoped = (url.compare(0, embed_scheme.size(), embed_scheme) == 0);
+    }
+
     std::vector<std::string>::iterator iter = mParent->getCustomSchemes().begin();
     while (iter != mParent->getCustomSchemes().end())
     {
@@ -396,7 +404,7 @@ CefRefPtr<CefResourceRequestHandler> dullahan_browser_client::GetResourceRequest
 // Top-level main-frame navigations are excluded here, because those are gated by
 // OnBeforeBrowse, so the initial embed:// document load is not blocked.
 cef_return_value_t dullahan_browser_client::OnBeforeResourceLoad(
-    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefBrowser> /*browser*/,
     CefRefPtr<CefFrame> /*frame*/,
     CefRefPtr<CefRequest> request,
     CefRefPtr<CefCallback> /*callback*/)
@@ -420,19 +428,14 @@ cef_return_value_t dullahan_browser_client::OnBeforeResourceLoad(
         return true;
     };
 
-    // Determine trust context from the browser's top-level document. Any nested
-    // frame within an embed:// document inherits the same rules.
-    std::string main_url;
-    if (browser)
-    {
-        CefRefPtr<CefFrame> main_frame = browser->GetMainFrame();
-        if (main_frame) main_url = main_frame->GetURL();
-    }
-    std::string req_url = request->GetURL();
+    // Trust context is set by OnBeforeBrowse when the main frame navigates.
+    // OnBeforeBrowse is guaranteed to fire before any sub-resource of the new
+    // page, so this is not subject to the IO-thread staleness of frame URLs.
+    const bool embed_context = mEmbedScoped.load(std::memory_order_relaxed);
 
-    const bool embed_context = starts_with(main_url, embed_prefix);
-    const bool req_is_embed  = starts_with(req_url, embed_prefix);
-    const bool req_is_data   = starts_with(req_url, data_prefix);
+    std::string req_url = request->GetURL();
+    const bool req_is_embed = starts_with(req_url, embed_prefix);
+    const bool req_is_data  = starts_with(req_url, data_prefix);
 
     if (embed_context)
     {

--- a/src/dullahan_browser_client.cpp
+++ b/src/dullahan_browser_client.cpp
@@ -72,8 +72,16 @@ bool dullahan_browser_client::OnProcessMessageReceived(CefRefPtr<CefBrowser> bro
         CefRefPtr<CefListValue> args = message->GetArgumentList();
         if (args)
         {
+            // Args: [0] id, [1] json, [2] frame_url (added for embed:// origin checks).
+            std::string frame_url;
+            if (args->GetSize() >= 3 && args->GetType(2) == VTYPE_STRING)
+            {
+                frame_url = args->GetString(2).ToString();
+            }
             //std::cout << ">>> Received JSONtoCPP_MSG from render process: " << args->GetString(0).ToString() << std::endl;
-            mParent->getCallbackManager()->onJStoCPPMsgCallback(args->GetString(0).ToString(), args->GetString(1).ToString());
+            mParent->getCallbackManager()->onJStoCPPMsgCallback(args->GetString(0).ToString(),
+                                                                 args->GetString(1).ToString(),
+                                                                 frame_url);
         }
 
         // Indicate we processed this message and it should not be sent to other handlers
@@ -304,6 +312,17 @@ bool dullahan_browser_client::OnBeforeBrowse(CefRefPtr<CefBrowser> browser,
     {
         return static_cast<char>(tolower(c));
     });
+
+    // Block any user-initiated navigation or redirect into embed://.
+    // Only the host process may load embed:// URLs directly.
+    static const std::string embed_scheme("embed://");
+    if (url.compare(0, embed_scheme.size(), embed_scheme) == 0)
+    {
+        if (user_gesture || isRedirect)
+        {
+            return true; // cancel navigation
+        }
+    }
 
     std::vector<std::string>::iterator iter = mParent->getCustomSchemes().begin();
     while (iter != mParent->getCustomSchemes().end())

--- a/src/dullahan_browser_client.cpp
+++ b/src/dullahan_browser_client.cpp
@@ -374,6 +374,83 @@ bool dullahan_browser_client::GetAuthCredentials(CefRefPtr<CefBrowser> browser, 
     }
 }
 
+// CefRequestHandler override - route resource requests through this same object.
+CefRefPtr<CefResourceRequestHandler> dullahan_browser_client::GetResourceRequestHandler(
+    CefRefPtr<CefBrowser> /*browser*/,
+    CefRefPtr<CefFrame> /*frame*/,
+    CefRefPtr<CefRequest> /*request*/,
+    bool /*is_navigation*/,
+    bool /*is_download*/,
+    const CefString& /*request_initiator*/,
+    bool& /*disable_default_handling*/)
+{
+    return this;
+}
+
+// CefResourceRequestHandler override - recursive inheritance for embed://.
+//
+// A browser whose top-level document is an embed:// page must not make sub-
+// resource requests to any other origin.
+// Conversely, a browser NOT running embed:// content must not fetch embed://
+// resources.
+// Top-level main-frame navigations are excluded here, because those are gated by
+// OnBeforeBrowse, so the initial embed:// document load is not blocked.
+cef_return_value_t dullahan_browser_client::OnBeforeResourceLoad(
+    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefFrame> /*frame*/,
+    CefRefPtr<CefRequest> request,
+    CefRefPtr<CefCallback> /*callback*/)
+{
+    // Skip the main-frame document itself; OnBeforeBrowse governs it.
+    if (request->GetResourceType() == RT_MAIN_FRAME)
+    {
+        return RV_CONTINUE;
+    }
+
+    static const std::string embed_prefix("embed://");
+    static const std::string data_prefix("data:");
+
+    auto starts_with = [](const std::string& s, const std::string& prefix)
+    {
+        if (s.size() < prefix.size()) return false;
+        for (size_t i = 0; i < prefix.size(); ++i)
+        {
+            if (tolower(static_cast<unsigned char>(s[i])) != prefix[i]) return false;
+        }
+        return true;
+    };
+
+    // Determine trust context from the browser's top-level document. Any nested
+    // frame within an embed:// document inherits the same rules.
+    std::string main_url;
+    if (browser)
+    {
+        CefRefPtr<CefFrame> main_frame = browser->GetMainFrame();
+        if (main_frame) main_url = main_frame->GetURL();
+    }
+    std::string req_url = request->GetURL();
+
+    const bool embed_context = starts_with(main_url, embed_prefix);
+    const bool req_is_embed  = starts_with(req_url, embed_prefix);
+    const bool req_is_data   = starts_with(req_url, data_prefix);
+
+    if (embed_context)
+    {
+        // embed:// documents may only load embed:// or data: resources.
+        if (!req_is_embed && !req_is_data)
+        {
+            return RV_CANCEL;
+        }
+    }
+    else if (req_is_embed)
+    {
+        // Non-embed documents may not touch embed:// resources at all.
+        return RV_CANCEL;
+    }
+
+    return RV_CONTINUE;
+}
+
 // CefDownloadHandler overrides
 bool dullahan_browser_client::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
     CefRefPtr<CefDownloadItem> download_item,

--- a/src/dullahan_browser_client.h
+++ b/src/dullahan_browser_client.h
@@ -40,6 +40,7 @@ class dullahan_browser_client :
     public CefDisplayHandler,
     public CefLoadHandler,
     public CefRequestHandler,
+    public CefResourceRequestHandler,
     public CefDownloadHandler,
     public CefDialogHandler,
     public CefJSDialogHandler
@@ -125,6 +126,16 @@ class dullahan_browser_client :
         bool GetAuthCredentials(CefRefPtr<CefBrowser> browser, const CefString& origin_url, bool isProxy,
                                 const CefString& host, int port, const CefString& realm,
                                 const CefString& scheme, CefRefPtr<CefAuthCallback> callback) override;
+
+        // CefRequestHandler -> CefResourceRequestHandler routing
+        CefRefPtr<CefResourceRequestHandler> GetResourceRequestHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                                                                       CefRefPtr<CefRequest> request, bool is_navigation,
+                                                                       bool is_download, const CefString& request_initiator,
+                                                                       bool& disable_default_handling) override;
+
+        // CefResourceRequestHandler override - enforces recursive inheritance for the embed:// scheme
+        cef_return_value_t OnBeforeResourceLoad(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                                                CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback) override;
 
         // CefDownloadHandler overrides
         CefRefPtr<CefDownloadHandler> GetDownloadHandler() override

--- a/src/dullahan_browser_client.h
+++ b/src/dullahan_browser_client.h
@@ -27,6 +27,7 @@
 #ifndef _DULLAHAN_BROWSER_CLIENT
 #define _DULLAHAN_BROWSER_CLIENT
 
+#include <atomic>
 #include <list>
 
 #include "cef_client.h"
@@ -187,6 +188,8 @@ class dullahan_browser_client :
         CefRefPtr<CefRenderHandler> mRenderHandler;
         typedef std::list<CefRefPtr<CefBrowser>> BrowserList;
         BrowserList mBrowserList;
+
+        std::atomic<bool> mEmbedScoped{false};
 
     public:
         IMPLEMENT_REFCOUNTING(dullahan_browser_client);

--- a/src/dullahan_callback_manager.cpp
+++ b/src/dullahan_callback_manager.cpp
@@ -293,16 +293,16 @@ bool dullahan_callback_manager::onJSBeforeUnloadCallback()
 }
 
 void dullahan_callback_manager::setOnJStoCPPMsgCallback(
-    std::function<std::string(const std::string id, const std::string msg)> callback)
+    std::function<std::string(const std::string id, const std::string msg, const std::string frame_url)> callback)
 {
     mOnJStoCPPMsgCallbackFunc = callback;
 }
 
-std::string dullahan_callback_manager::onJStoCPPMsgCallback(const std::string id, const std::string msg)
+std::string dullahan_callback_manager::onJStoCPPMsgCallback(const std::string id, const std::string msg, const std::string frame_url)
 {
     if (mOnJStoCPPMsgCallbackFunc)
     {
-        return mOnJStoCPPMsgCallbackFunc(id, msg);
+        return mOnJStoCPPMsgCallbackFunc(id, msg, frame_url);
     }
 
     return std::string();

--- a/src/dullahan_callback_manager.h
+++ b/src/dullahan_callback_manager.h
@@ -91,8 +91,8 @@ class dullahan_callback_manager
         void setOnJSBeforeUnloadCallback(std::function<bool()> callback);
         bool onJSBeforeUnloadCallback();
 
-        void setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg)> callback);
-        std::string onJStoCPPMsgCallback(const std::string id, const std::string msg);
+        void setOnJStoCPPMsgCallback(std::function<std::string(const std::string id, const std::string msg, const std::string frame_url)> callback);
+        std::string onJStoCPPMsgCallback(const std::string id, const std::string msg, const std::string frame_url);
 
     private:
         std::function<void(const std::string)> mOnAddressChangeCallbackFunc;
@@ -114,7 +114,7 @@ class dullahan_callback_manager
         std::function<const std::vector<std::string>(dullahan::EFileDialogType, const std::string, const std::string, const std::string, bool&)> mOnFileDialogCallbackFunc;
         std::function<bool(const std::string, const std::string, const std::string)> mOnJSDialogCallbackFunc;
         std::function<bool()> mOnJSBeforeUnloadCallbackFunc;
-        std::function<std::string(const std::string id, const std::string)> mOnJStoCPPMsgCallbackFunc;
+        std::function<std::string(const std::string id, const std::string msg, const std::string frame_url)> mOnJStoCPPMsgCallbackFunc;
 };
 
 #endif //_DULLAHAN_CALLBACK_MANAGER

--- a/src/dullahan_embed_scheme.cpp
+++ b/src/dullahan_embed_scheme.cpp
@@ -31,12 +31,11 @@
 #include "dullahan_impl.h"
 
 #include "cef_parser.h"
+#include "cef_stream.h"
+#include "wrapper/cef_stream_resource_handler.h"
 
 #include <algorithm>
-#include <cstdio>
 #include <cstring>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -59,20 +58,6 @@ namespace
         if (ext == "jpg" || ext == "jpeg") return "image/jpeg";
         if (ext == "gif")                  return "image/gif";
         return "application/octet-stream";
-    }
-
-    // Read an entire file into a byte vector;
-    bool read_file_bytes(const std::string& disk_path, std::vector<unsigned char>& out)
-    {
-        std::ifstream in(disk_path, std::ios::binary);
-        if (!in) return false;
-        in.seekg(0, std::ios::end);
-        std::streamsize size = in.tellg();
-        if (size < 0) return false;
-        in.seekg(0, std::ios::beg);
-        out.resize(static_cast<size_t>(size));
-        if (size > 0 && !in.read(reinterpret_cast<char*>(out.data()), size)) return false;
-        return true;
     }
 
     // Strip query string / fragment and any leading '/'; also normalise backslashes.
@@ -98,80 +83,58 @@ namespace
         return true;
     }
 
-    // Resource handler that serves a pre-loaded byte buffer with a given MIME type.
-    // Uses CefStreamResourceHandler via an in-memory CefStreamReader, or a simple
-    // hand-rolled CefResourceHandler if we need finer control.
-    class embed_resource_handler : public CefResourceHandler
+    // In-memory CefReadHandler backed by a std::string. Used for the short
+    // canned bodies of error responses so we can serve them through the same
+    // CefStreamResourceHandler that we use for real file bodies.
+    class string_read_handler : public CefReadHandler
     {
         public:
-            embed_resource_handler(std::vector<unsigned char>&& data,
-                                   const std::string& mime,
-                                   int status_code,
-                                   const std::string& status_text) :
-                mData(std::move(data)),
-                mMime(mime),
-                mStatus(status_code),
-                mStatusText(status_text),
+            explicit string_read_handler(std::string body) :
+                mData(std::move(body)),
                 mOffset(0)
             {
             }
 
-            bool Open(CefRefPtr<CefRequest> request, bool& handle_request,
-                      CefRefPtr<CefCallback> callback) override
+            size_t Read(void* ptr, size_t elem_size, size_t n) override
             {
-                handle_request = true;
-                return true;
-            }
-
-            void GetResponseHeaders(CefRefPtr<CefResponse> response,
-                                    int64_t& response_length,
-                                    CefString& redirectUrl) override
-            {
-                response->SetMimeType(mMime);
-                response->SetStatus(mStatus);
-                if (!mStatusText.empty())
-                {
-                    response->SetStatusText(mStatusText);
-                }
-                CefResponse::HeaderMap headers;
-                headers.insert(std::make_pair("Cache-Control", "no-store"));
-                headers.insert(std::make_pair("Access-Control-Allow-Origin", "*"));
-                response->SetHeaderMap(headers);
-                response_length = static_cast<int64_t>(mData.size());
-            }
-
-            bool Read(void* data_out, int bytes_to_read, int& bytes_read,
-                      CefRefPtr<CefResourceReadCallback> callback) override
-            {
-                bytes_read = 0;
-                if (mOffset >= mData.size()) return false;
+                size_t bytes_wanted = elem_size * n;
                 size_t remaining = mData.size() - mOffset;
-                int to_copy = static_cast<int>(std::min<size_t>(remaining,
-                                                                 static_cast<size_t>(bytes_to_read)));
-                std::memcpy(data_out, mData.data() + mOffset, to_copy);
-                mOffset += to_copy;
-                bytes_read = to_copy;
-                return true;
+                size_t to_copy = std::min(bytes_wanted, remaining);
+                if (to_copy > 0)
+                {
+                    std::memcpy(ptr, mData.data() + mOffset, to_copy);
+                    mOffset += to_copy;
+                }
+                return elem_size ? (to_copy / elem_size) : 0;
             }
 
-            void Cancel() override {}
+            int Seek(int64_t /*offset*/, int /*whence*/) override { return -1; }
+            int64_t Tell() override { return static_cast<int64_t>(mOffset); }
+            int Eof() override { return mOffset >= mData.size() ? 1 : 0; }
+            bool MayBlock() override { return false; }
 
         private:
-            std::vector<unsigned char> mData;
-            std::string mMime;
-            int mStatus;
-            std::string mStatusText;
+            std::string mData;
             size_t mOffset;
 
-            IMPLEMENT_REFCOUNTING(embed_resource_handler);
-            DISALLOW_COPY_AND_ASSIGN(embed_resource_handler);
+            IMPLEMENT_REFCOUNTING(string_read_handler);
+            DISALLOW_COPY_AND_ASSIGN(string_read_handler);
     };
+
+    CefResponse::HeaderMap default_headers()
+    {
+        CefResponse::HeaderMap headers;
+        headers.insert(std::make_pair("Cache-Control", "no-store"));
+        headers.insert(std::make_pair("Access-Control-Allow-Origin", "*"));
+        return headers;
+    }
 
     CefRefPtr<CefResourceHandler> make_error(int status, const std::string& reason)
     {
         std::string body = "embed:// " + reason;
-        std::vector<unsigned char> bytes(body.begin(), body.end());
-        return new embed_resource_handler(std::move(bytes), "text/plain", status, reason);
+        CefRefPtr<CefStreamReader> stream =
+            CefStreamReader::CreateForHandler(new string_read_handler(std::move(body)));
+        return new CefStreamResourceHandler(status, reason, "text/plain", default_headers(), stream);
     }
 }
 
@@ -231,11 +194,14 @@ CefRefPtr<CefResourceHandler> dullahan_embed_scheme_factory::Create(
     }
     disk_path += relpath;
 
-    std::vector<unsigned char> bytes;
-    if (!read_file_bytes(disk_path, bytes))
+    // Delegate file I/O to CEF. CefStreamReader::CreateForFile takes a
+    // CefString (UTF-16 internally), so any UTF-8 path works correctly on
+    // Windows - unlike std::ifstream, which silently fails on UTF-8 paths.
+    CefRefPtr<CefStreamReader> stream = CefStreamReader::CreateForFile(disk_path);
+    if (!stream)
     {
         return make_error(404, "file not found");
     }
 
-    return new embed_resource_handler(std::move(bytes), mime_for_path(relpath), 200, "OK");
+    return new CefStreamResourceHandler(200, "OK", mime_for_path(relpath), default_headers(), stream);
 }

--- a/src/dullahan_embed_scheme.cpp
+++ b/src/dullahan_embed_scheme.cpp
@@ -25,6 +25,8 @@
 
 // embed:// custom scheme handler implementation
 
+#define NOMINMAX
+
 #include "dullahan_embed_scheme.h"
 #include "dullahan_impl.h"
 

--- a/src/dullahan_embed_scheme.cpp
+++ b/src/dullahan_embed_scheme.cpp
@@ -178,8 +178,28 @@ CefRefPtr<CefResourceHandler> dullahan_embed_scheme_factory::Create(
         return make_error(400, "invalid path");
     }
 
-    // Registry lookup, relative paths use forward slashes.
-    if (std::find(registry.begin(), registry.end(), relpath) == registry.end())
+    // Registry lookup, relative paths use forward slashes. An entry ending
+    // in '/' is treated as a directory prefix - any relpath under that folder
+    // is allowed. Any other entry must match relpath exactly.
+    bool matched = false;
+    for (const std::string& entry : registry)
+    {
+        if (entry.empty()) continue;
+        if (entry.back() == '/')
+        {
+            if (relpath.compare(0, entry.size(), entry) == 0)
+            {
+                matched = true;
+                break;
+            }
+        }
+        else if (relpath == entry)
+        {
+            matched = true;
+            break;
+        }
+    }
+    if (!matched)
     {
         return make_error(404, "not in registry");
     }

--- a/src/dullahan_embed_scheme.cpp
+++ b/src/dullahan_embed_scheme.cpp
@@ -1,0 +1,239 @@
+/*
+    @brief Dullahan - a headless browser rendering engine
+           based around the Chromium Embedded Framework
+
+    Copyright (c) 2026, Linden Research, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+// embed:// custom scheme handler implementation
+
+#include "dullahan_embed_scheme.h"
+#include "dullahan_impl.h"
+
+#include "cef_parser.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    // MIME map for the file types the embed scheme uses.
+    std::string mime_for_path(const std::string& path)
+    {
+        auto dot = path.find_last_of('.');
+        std::string ext = (dot == std::string::npos) ? std::string() : path.substr(dot + 1);
+        std::transform(ext.begin(), ext.end(), ext.begin(),
+                       [](char c) { return static_cast<char>(tolower(c)); });
+
+        if (ext == "html" || ext == "htm") return "text/html";
+        if (ext == "js")                   return "application/javascript";
+        if (ext == "css")                  return "text/css";
+        if (ext == "json")                 return "application/json";
+        if (ext == "svg")                  return "image/svg+xml";
+        if (ext == "png")                  return "image/png";
+        if (ext == "jpg" || ext == "jpeg") return "image/jpeg";
+        if (ext == "gif")                  return "image/gif";
+        return "application/octet-stream";
+    }
+
+    // Read an entire file into a byte vector;
+    bool read_file_bytes(const std::string& disk_path, std::vector<unsigned char>& out)
+    {
+        std::ifstream in(disk_path, std::ios::binary);
+        if (!in) return false;
+        in.seekg(0, std::ios::end);
+        std::streamsize size = in.tellg();
+        if (size < 0) return false;
+        in.seekg(0, std::ios::beg);
+        out.resize(static_cast<size_t>(size));
+        if (size > 0 && !in.read(reinterpret_cast<char*>(out.data()), size)) return false;
+        return true;
+    }
+
+    // Strip query string / fragment and any leading '/'; also normalise backslashes.
+    std::string canonical_relpath(const std::string& host, const std::string& path)
+    {
+        std::string p = path;
+        auto q = p.find_first_of("?#");
+        if (q != std::string::npos) p.erase(q);
+        while (!p.empty() && p.front() == '/') p.erase(0, 1);
+        std::replace(p.begin(), p.end(), '\\', '/');
+        std::string relpath = host;
+        if (!relpath.empty() && !p.empty()) relpath.push_back('/');
+        relpath += p;
+        return relpath;
+    }
+
+    // Reject any relpath containing "..", empty segments, or non-relative form.
+    bool relpath_is_safe(const std::string& relpath)
+    {
+        if (relpath.empty()) return false;
+        if (relpath.front() == '/') return false;
+        if (relpath.find("..") != std::string::npos) return false;
+        return true;
+    }
+
+    // Resource handler that serves a pre-loaded byte buffer with a given MIME type.
+    // Uses CefStreamResourceHandler via an in-memory CefStreamReader, or a simple
+    // hand-rolled CefResourceHandler if we need finer control.
+    class embed_resource_handler : public CefResourceHandler
+    {
+        public:
+            embed_resource_handler(std::vector<unsigned char>&& data,
+                                   const std::string& mime,
+                                   int status_code,
+                                   const std::string& status_text) :
+                mData(std::move(data)),
+                mMime(mime),
+                mStatus(status_code),
+                mStatusText(status_text),
+                mOffset(0)
+            {
+            }
+
+            bool Open(CefRefPtr<CefRequest> request, bool& handle_request,
+                      CefRefPtr<CefCallback> callback) override
+            {
+                handle_request = true;
+                return true;
+            }
+
+            void GetResponseHeaders(CefRefPtr<CefResponse> response,
+                                    int64_t& response_length,
+                                    CefString& redirectUrl) override
+            {
+                response->SetMimeType(mMime);
+                response->SetStatus(mStatus);
+                if (!mStatusText.empty())
+                {
+                    response->SetStatusText(mStatusText);
+                }
+                CefResponse::HeaderMap headers;
+                headers.insert(std::make_pair("Cache-Control", "no-store"));
+                headers.insert(std::make_pair("Access-Control-Allow-Origin", "*"));
+                response->SetHeaderMap(headers);
+                response_length = static_cast<int64_t>(mData.size());
+            }
+
+            bool Read(void* data_out, int bytes_to_read, int& bytes_read,
+                      CefRefPtr<CefResourceReadCallback> callback) override
+            {
+                bytes_read = 0;
+                if (mOffset >= mData.size()) return false;
+                size_t remaining = mData.size() - mOffset;
+                int to_copy = static_cast<int>(std::min<size_t>(remaining,
+                                                                 static_cast<size_t>(bytes_to_read)));
+                std::memcpy(data_out, mData.data() + mOffset, to_copy);
+                mOffset += to_copy;
+                bytes_read = to_copy;
+                return true;
+            }
+
+            void Cancel() override {}
+
+        private:
+            std::vector<unsigned char> mData;
+            std::string mMime;
+            int mStatus;
+            std::string mStatusText;
+            size_t mOffset;
+
+            IMPLEMENT_REFCOUNTING(embed_resource_handler);
+            DISALLOW_COPY_AND_ASSIGN(embed_resource_handler);
+    };
+
+    CefRefPtr<CefResourceHandler> make_error(int status, const std::string& reason)
+    {
+        std::string body = "embed:// " + reason;
+        std::vector<unsigned char> bytes(body.begin(), body.end());
+        return new embed_resource_handler(std::move(bytes), "text/plain", status, reason);
+    }
+}
+
+dullahan_embed_scheme_factory::dullahan_embed_scheme_factory(dullahan_impl* parent) :
+    mParent(parent)
+{
+}
+
+CefRefPtr<CefResourceHandler> dullahan_embed_scheme_factory::Create(
+    CefRefPtr<CefBrowser> /*browser*/,
+    CefRefPtr<CefFrame> /*frame*/,
+    const CefString& /*scheme_name*/,
+    CefRefPtr<CefRequest> request)
+{
+    if (!mParent)
+    {
+        return make_error(500, "no host");
+    }
+
+    const std::string& root = mParent->getEmbedSchemeRoot();
+    const std::vector<std::string>& registry = mParent->getEmbedRegistry();
+    if (root.empty())
+    {
+        return make_error(500, "embed root not configured");
+    }
+
+    // Parse the URL into pieces.
+    CefURLParts parts;
+    if (!CefParseURL(request->GetURL(), parts))
+    {
+        return make_error(400, "bad url");
+    }
+    std::string host = CefString(&parts.host).ToString();
+    std::string path = CefString(&parts.path).ToString();
+    std::transform(host.begin(), host.end(), host.begin(),
+                   [](char c) { return static_cast<char>(tolower(c)); });
+
+    std::string relpath = canonical_relpath(host, path);
+    if (!relpath_is_safe(relpath))
+    {
+        return make_error(400, "invalid path");
+    }
+
+    // Registry lookup, relative paths use forward slashes.
+    if (std::find(registry.begin(), registry.end(), relpath) == registry.end())
+    {
+        return make_error(404, "not in registry");
+    }
+
+    // Compose on-disk path.
+    std::string disk_path = root;
+    if (!disk_path.empty() &&
+        disk_path.back() != '/' &&
+        disk_path.back() != '\\')
+    {
+        disk_path.push_back('/');
+    }
+    disk_path += relpath;
+
+    std::vector<unsigned char> bytes;
+    if (!read_file_bytes(disk_path, bytes))
+    {
+        return make_error(404, "file not found");
+    }
+
+    return new embed_resource_handler(std::move(bytes), mime_for_path(relpath), 200, "OK");
+}

--- a/src/dullahan_embed_scheme.h
+++ b/src/dullahan_embed_scheme.h
@@ -1,0 +1,61 @@
+/*
+    @brief Dullahan - a headless browser rendering engine
+           based around the Chromium Embedded Framework
+
+    Copyright (c) 2026, Linden Research, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+// embed:// custom scheme handler
+//
+// Implements the embed:// scheme used to serve trusted local resources
+// bundled by the host application. Files are mapped as
+//
+//     embed://<host>/<path>   =>   <root>/<host>/<path>
+//
+// Only paths listed in the registry (relative to <root>, using forward
+// slashes) are served; any other request produces a 404.
+
+#ifndef _DULLAHAN_EMBED_SCHEME
+#define _DULLAHAN_EMBED_SCHEME
+
+#include "cef_scheme.h"
+
+class dullahan_impl;
+
+// Factory returned to CEF via CefRegisterSchemeHandlerFactory.
+// Holds a raw pointer to the owning dullahan_impl for access to
+// the configured filesystem root and allowlist.
+class dullahan_embed_scheme_factory : public CefSchemeHandlerFactory
+{
+    public:
+        explicit dullahan_embed_scheme_factory(dullahan_impl* parent);
+
+        CefRefPtr<CefResourceHandler> Create(CefRefPtr<CefBrowser> browser,
+                                             CefRefPtr<CefFrame> frame,
+                                             const CefString& scheme_name,
+                                             CefRefPtr<CefRequest> request) override;
+
+    private:
+        dullahan_impl* mParent;
+        IMPLEMENT_REFCOUNTING(dullahan_embed_scheme_factory);
+};
+
+#endif // _DULLAHAN_EMBED_SCHEME

--- a/src/dullahan_impl.cpp
+++ b/src/dullahan_impl.cpp
@@ -33,9 +33,11 @@
 #include "dullahan_render_handler.h"
 #include "dullahan_browser_client.h"
 #include "dullahan_callback_manager.h"
+#include "dullahan_embed_scheme.h"
 
 #include "include/cef_request_context.h"
 #include "include/cef_request_context_handler.h"
+#include "include/cef_scheme.h"
 #include "include/cef_waitable_event.h"
 #include "include/base/cef_logging.h"
 
@@ -1091,6 +1093,47 @@ void dullahan_impl::setCustomSchemes(std::vector<std::string> custom_schemes)
 std::vector<std::string>& dullahan_impl::getCustomSchemes()
 {
     return mCustomSchemes;
+}
+
+void dullahan_impl::setEmbedSchemeRoot(const std::string& root_dir)
+{
+    mEmbedSchemeRoot = root_dir;
+}
+
+const std::string& dullahan_impl::getEmbedSchemeRoot()
+{
+    return mEmbedSchemeRoot;
+}
+
+void dullahan_impl::setEmbedRegistry(const std::vector<std::string>& allowed_paths)
+{
+    mEmbedRegistry = allowed_paths;
+}
+
+const std::vector<std::string>& dullahan_impl::getEmbedRegistry()
+{
+    return mEmbedRegistry;
+}
+
+// CefApp override. Called in every process (browser + all sub-processes) early during initialisation.
+// Registers embed:// with both CEF's network stack (so requests are routed through our scheme handler factory)
+// and Chromium's renderer (so embed:// documents are treated as a proper secure origin).
+void dullahan_impl::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
+{
+    registrar->AddCustomScheme("embed",
+                               CEF_SCHEME_OPTION_STANDARD |
+                               CEF_SCHEME_OPTION_SECURE |
+                               CEF_SCHEME_OPTION_CORS_ENABLED |
+                               CEF_SCHEME_OPTION_FETCH_ENABLED |
+                               CEF_SCHEME_OPTION_LOCAL);
+}
+
+// CefBrowserProcessHandler override. Runs in the browser process after the
+// CEF context is initialised. Register the embed:// scheme handler factory
+// here so the factory pointer to dullahan_impl is guaranteed to be valid.
+void dullahan_impl::OnContextInitialized()
+{
+    CefRegisterSchemeHandlerFactory("embed", CefString(), new dullahan_embed_scheme_factory(this));
 }
 
 CefRefPtr<CefBrowser> dullahan_impl::getBrowser()

--- a/src/dullahan_impl.h
+++ b/src/dullahan_impl.h
@@ -47,6 +47,7 @@ class CefRequestContext;
 
 class dullahan_impl :
     public CefApp,
+    public CefBrowserProcessHandler,
     public CefPdfPrintCallback
 {
         void platormInitWidevine(std::string cachePath);
@@ -57,6 +58,11 @@ class dullahan_impl :
 
         // CefApp overrides
         virtual void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override;
+        virtual void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override;
+        virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override { return this; }
+
+        // CefBrowserProcessHandler overrides
+        virtual void OnContextInitialized() override;
 
         bool init(dullahan::dullahan_settings& user_settings);
         void shutdown();
@@ -140,6 +146,11 @@ class dullahan_impl :
         void setCustomSchemes(std::vector<std::string> custom_schemes);
         std::vector<std::string>& getCustomSchemes();
 
+        void setEmbedSchemeRoot(const std::string& root_dir);
+        const std::string& getEmbedSchemeRoot();
+        void setEmbedRegistry(const std::vector<std::string>& allowed_paths);
+        const std::vector<std::string>& getEmbedRegistry();
+
         CefRefPtr<CefBrowser> getBrowser();
         void setBrowser(CefRefPtr<CefBrowser> browser);
 
@@ -183,6 +194,8 @@ class dullahan_impl :
         double mRequestedPageZoom;
         const int mViewDepth = 4;
         std::vector<std::string> mCustomSchemes;
+        std::string mEmbedSchemeRoot;
+        std::vector<std::string> mEmbedRegistry;
 
         IMPLEMENT_REFCOUNTING(dullahan_impl);
 };

--- a/src/host/dullahan_host.cpp
+++ b/src/host/dullahan_host.cpp
@@ -27,15 +27,41 @@
 #define NOMINMAX
 
 #include "cef_app.h"
+#include "cef_scheme.h"
+
+#include <string>
+
+namespace
+{
+    // CEF requires the same registration in every process before initialisation.
+    // Must match dullahan_impl::OnRegisterCustomSchemes exactly
+    const char* kEmbedScheme = "embed";
+    const char* kEmbedSchemePrefix = "embed://";
+
+    bool url_is_embed(const std::string& url)
+    {
+        static const std::string prefix(kEmbedSchemePrefix);
+        if (url.size() < prefix.size()) return false;
+        // Scheme comparison is case-insensitive.
+        for (size_t i = 0; i < prefix.size(); ++i)
+        {
+            if (tolower(static_cast<unsigned char>(url[i])) != prefix[i]) return false;
+        }
+        return true;
+    }
+}
 
 // Shared by Windows and Mac sub-process entry points
 class JSONtoCPPHandler : public CefV8Handler
 {
     public:
-        JSONtoCPPHandler(CefRefPtr<CefBrowser> browser) :
-            // Save the browser reference from OnContextCreated()
-            // for later use in IPC communication
-            mBrowser(browser)
+        JSONtoCPPHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame) :
+            // Save the browser + frame references from OnContextCreated()
+            // for later use in IPC communication. The frame reference is used
+            // so the browser process can identify which document originated
+            // each message (for embed:// origin checks).
+            mBrowser(browser),
+            mFrame(frame)
         {
         }
 
@@ -76,6 +102,8 @@ class JSONtoCPPHandler : public CefV8Handler
             CefRefPtr<CefListValue> args = msg->GetArgumentList();
             args->SetString(0, id);
             args->SetString(1, json);
+            std::string frame_url = mFrame ? std::string(mFrame->GetURL()) : std::string();
+            args->SetString(2, frame_url);
             mBrowser->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
 
             // Acknowledge receipt of the JSON string
@@ -83,6 +111,7 @@ class JSONtoCPPHandler : public CefV8Handler
         }
 
         CefRefPtr<CefBrowser> mBrowser;
+        CefRefPtr<CefFrame> mFrame;
         IMPLEMENT_REFCOUNTING(JSONtoCPPHandler);
 };
 
@@ -95,12 +124,32 @@ public:
         return this;
     }
 
+    // CefApp override. Runs in every process. Must register the embed://
+    // scheme with the same flags as the browser process so Chromium's renderer
+    // treats embed:// documents as a proper (secure) origin.
+    void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override
+    {
+        registrar->AddCustomScheme(kEmbedScheme,
+                                   CEF_SCHEME_OPTION_STANDARD |
+                                   CEF_SCHEME_OPTION_SECURE |
+                                   CEF_SCHEME_OPTION_CORS_ENABLED |
+                                   CEF_SCHEME_OPTION_FETCH_ENABLED |
+                                   CEF_SCHEME_OPTION_LOCAL);
+    }
+
     void OnContextCreated(CefRefPtr<CefBrowser> browser,
                           CefRefPtr<CefFrame> frame,
                           CefRefPtr<CefV8Context> context) override
     {
+        // Only inject the window.JSONtoCPP bridge on trusted embed:// frames.
+        std::string url = frame ? std::string(frame->GetURL()) : std::string();
+        if (!url_is_embed(url))
+        {
+            return;
+        }
+
         CefRefPtr<CefV8Value> global = context->GetGlobal();
-        CefRefPtr<CefV8Handler> handler = new JSONtoCPPHandler(browser);
+        CefRefPtr<CefV8Handler> handler = new JSONtoCPPHandler(browser, frame);
         CefRefPtr<CefV8Value> func = CefV8Value::CreateFunction("JSONtoCPP", handler);
         global->SetValue("JSONtoCPP", func, V8_PROPERTY_ATTRIBUTE_NONE);
 
@@ -109,6 +158,7 @@ public:
         CefRefPtr<CefListValue> args = msg->GetArgumentList();
         args->SetString(0, "INFO");
         args->SetString(1, "Hello from the OnContextCreated in the sub-process!");
+        args->SetString(2, url);
         browser->GetMainFrame()->SendProcessMessage(PID_BROWSER, msg);
     }
 
@@ -123,7 +173,8 @@ NO_STACK_PROTECTOR
 int main(int argc, char* argv[])
 {
     CefMainArgs main_args(argc, argv);
-    return CefExecuteProcess(main_args, nullptr, nullptr);
+    const CefRefPtr<MyApp> app = new MyApp();
+    return CefExecuteProcess(main_args, app, nullptr);
 }
 #endif
 #ifdef WIN32
@@ -187,7 +238,7 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
     CefMainArgs args(GetModuleHandle(nullptr));
 
-    // Important: Create the CefApp instance in the main function to ensure it is available
+    // Create the CefApp instance in the main function to ensure it is available
     // to CefExecuteProcess() when the sub-process is launched. Creating the CefApp instance
     const CefRefPtr<MyApp> app = new MyApp();
 


### PR DESCRIPTION
Added a new custom `embed://` scheme served entirely by Dullahan from an on-disk root that the Viewer configures. Content is treated by CEF as a proper secure origin.

**Registry allowlist**. The host configures a registry of allowed paths. Exact-match paths are supported for individual files; entries ending in / are treated as directory prefixes. Any request that doesn't match returns 404 without touching disk.
Related Viewer-side API: `setEmbedSchemeRoot(root_dir)` and `setEmbedRegistry(allowed_paths)` to configure the scheme handler.

**Bridge scoping.** The `window.JSONtoCPP` JS bridge is now injected only on frames whose URL is under `embed://`. Ordinary web pages don't see the bridge. Each JS→C++ message also carries the calling frame's URL so the host can verify origin.

**Recursive-inheritance enforcement.** A browser whose top-level document is an `embed://` page may only load `embed://` or `data:` sub-resources - no external iframes, images, scripts, stylesheets, fetches, or beacons. Conversely, a browser NOT running `embed://` content cannot fetch `embed://` resources. Applied via `OnBeforeResourceLoad`; enforced by tracking the trust context set in `OnBeforeBrowse` to avoid a UI/IO thread race that would otherwise misclassify sub-resources fired right after a navigation commits.

**Navigation lockdown.** Top-level navigation into `embed://` from a user-clicked link or an HTTP redirect is rejected. Loading `embed://` requires an explicit LoadURL call from the host.
